### PR TITLE
chore: use @boltz/bitcoin-ops library

### DIFF
--- a/lib/swap/Claim.ts
+++ b/lib/swap/Claim.ts
@@ -3,7 +3,7 @@
  */
 
 import { BIP32 } from 'bip32';
-import ops from '@michael1011/bitcoin-ops';
+import ops from '@boltz/bitcoin-ops';
 import * as bip65 from 'bip65';
 import * as varuint from 'varuint-bitcoin';
 import { Transaction, crypto, script, ECPair } from 'bitcoinjs-lib';

--- a/lib/swap/Refund.ts
+++ b/lib/swap/Refund.ts
@@ -4,7 +4,7 @@
 
 import { BIP32 } from 'bip32';
 import { ECPair } from 'bitcoinjs-lib';
-import ops from '@michael1011/bitcoin-ops';
+import ops from '@boltz/bitcoin-ops';
 import { TransactionOutput } from '../consts/Types';
 import { getHexBuffer } from '../Utils';
 import { constructClaimTransaction } from './Claim';

--- a/lib/swap/Scripts.ts
+++ b/lib/swap/Scripts.ts
@@ -3,7 +3,7 @@
  */
 
 import { script, crypto } from 'bitcoinjs-lib';
-import ops from '@michael1011/bitcoin-ops';
+import ops from '@boltz/bitcoin-ops';
 
 /**
  * Get a P2WPKH output script

--- a/lib/swap/Swap.ts
+++ b/lib/swap/Swap.ts
@@ -3,7 +3,7 @@
  */
 
 import { script, crypto } from 'bitcoinjs-lib';
-import ops from '@michael1011/bitcoin-ops';
+import ops from '@boltz/bitcoin-ops';
 import * as bip65 from 'bip65';
 import { toPushdataScript } from './SwapUtils';
 

--- a/lib/swap/SwapUtils.ts
+++ b/lib/swap/SwapUtils.ts
@@ -6,7 +6,7 @@
 import { script } from 'bitcoinjs-lib';
 import Bn from 'bn.js';
 import bip66 from 'bip66';
-import ops from '@michael1011/bitcoin-ops';
+import ops from '@boltz/bitcoin-ops';
 import * as varuint from 'varuint-bitcoin';
 import { getHexBuffer, getHexString } from '../Utils';
 import { ScriptElement } from '../consts/Types';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,14 @@
 {
   "name": "boltz-core",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@boltz/bitcoin-ops": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@boltz/bitcoin-ops/-/bitcoin-ops-2.0.0.tgz",
+      "integrity": "sha512-AM7vFNwSD7B4XI6yeRKccWbbD/lvwoFr8U3pqhzryBQo4uMkYe5V3/kMVnml4SNuxzyqdIFu4ur3TId02sC33A=="
+    },
     "@fimbul/bifrost": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@fimbul/bifrost/-/bifrost-0.15.0.tgz",
@@ -37,11 +42,6 @@
         "reflect-metadata": "^0.1.12",
         "tslib": "^1.8.1"
       }
-    },
-    "@michael1011/bitcoin-ops": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@michael1011/bitcoin-ops/-/bitcoin-ops-1.4.3.tgz",
-      "integrity": "sha512-U3KPRLaIdmbfbFrMaVV/CxZl3uzqvUU3lVeh2tnfxo48iduKFtQn1g5axGD+X2LD4f+0hu0u85bLQZ0JAzS95g=="
     },
     "@types/bitcoinjs-lib": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boltz-core",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Core library of Boltz",
   "main": "dist/Boltz.js",
   "scripts": {
@@ -27,7 +27,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@michael1011/bitcoin-ops": "^1.4.3",
+    "@boltz/bitcoin-ops": "^2.0.0",
     "bip65": "^1.0.3",
     "bip66": "^1.1.5",
     "bitcoinjs-lib": "^4.0.2",

--- a/test/unit/swap/SwapUtils.spec.ts
+++ b/test/unit/swap/SwapUtils.spec.ts
@@ -1,7 +1,7 @@
 // tslint:disable:max-line-length
 import { expect } from 'chai';
 import { Transaction, crypto, ECPair, address, script } from 'bitcoinjs-lib';
-import ops from '@michael1011/bitcoin-ops';
+import ops from '@boltz/bitcoin-ops';
 import { getHexString, getHexBuffer } from '../../../lib/Utils';
 import { encodeSignature, toPushdataScript, scriptBuffersToScript, getOutputScriptType } from '../../../lib/swap/SwapUtils';
 import Networks from '../../../lib/consts/Networks';


### PR DESCRIPTION
This PR switches from my personal fork of [bitcoin-ops](https://github.com/bitcoinjs/bitcoin-ops) [@michael1011/bitcoin-ops](https://www.npmjs.com/package/@michael1011/bitcoin-ops) to one managed by the Boltz NPM organisation [@boltz/bitcoin-ops](https://www.npmjs.com/package/@boltz/bitcoin-ops)