### PR TITLE
fix: hardcode dummy preimage

### DIFF
--- a/lib/swap/Refund.ts
+++ b/lib/swap/Refund.ts
@@ -4,13 +4,11 @@
 
 import { BIP32 } from 'bip32';
 import { ECPair } from 'bitcoinjs-lib';
-import ops from '@boltz/bitcoin-ops';
 import { TransactionOutput } from '../consts/Types';
 import { getHexBuffer } from '../Utils';
 import { constructClaimTransaction } from './Claim';
 
-const hexBase = 16;
-const dummyPreimage = getHexBuffer(ops.OP_FALSE.toString(hexBase));
+const dummyPreimage = getHexBuffer('0x00');
 
 /**
  * Refund a swap


### PR DESCRIPTION
The JavaScript `Buffer` behaves differently in the browser and causes errors like: `TypeError: Invalid hex string` and therefore the `dummyPreimage` needs to be hardcoded so that the library works properly in the browser.