### PR TITLE
tests: add tests for failing claim transactions

### DIFF
--- a/test/integration/swap/swapscript/SwapScriptClaim.spec.ts
+++ b/test/integration/swap/swapscript/SwapScriptClaim.spec.ts
@@ -1,8 +1,27 @@
+import { randomBytes } from 'crypto';
 import { claimDetails } from './SwapScript.spec';
 import { constructClaimTransaction } from '../../../../lib/Boltz';
 import { bitcoinClient, destinationOutput, claimSwap } from '../Utils';
 
 describe('SwapScript claim', () => {
+  test('should not claim swaps if the preimage has an invalid hash', async () => {
+    let actualError: any;
+
+    try {
+      const toClaim = {
+        ...claimDetails[0],
+      };
+      toClaim.preimage = randomBytes(32);
+
+      await claimSwap(toClaim);
+    } catch (error) {
+      actualError = error;
+    }
+
+    expect(actualError.code).toEqual(-26);
+    expect(actualError.message).toEqual('mandatory-script-verify-flag-failed (Locktime requirement not satisfied) (code 16)');
+  });
+
   test('should claim a P2WSH swap', async () => {
     await claimSwap(claimDetails[0]);
   });


### PR DESCRIPTION
To ensure that coins can't be claimed with an incorrect preimage I added two more test case that verify this behavior.