### PR TITLE
chore: bump CI Node.js to v24

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        node-version: [20, 22, 23]
+        node-version: [20, 22, 24]
 
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing environment to use Node.js version 24 instead of version 23 in continuous integration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->