### PR TITLE
feat: commitment swaps

### DIFF
--- a/contracts/test/RouterTest.sol
+++ b/contracts/test/RouterTest.sol
@@ -198,7 +198,7 @@ contract RouterTest is Test {
         calls[0] = Router.Call({
             target: address(SWAP),
             value: 0,
-            callData: abi.encodeWithSelector(EtherSwap.claimBatch.selector)
+            callData: abi.encodeWithSelector(EtherSwap.refundCooperative.selector)
         });
 
         vm.prank(claimAddress);

--- a/contracts/test/SigUtils.sol
+++ b/contracts/test/SigUtils.sol
@@ -67,4 +67,17 @@ contract SigUtils {
     ) public pure returns (bytes32) {
         return keccak256(abi.encode(typehash, preimageHash, amount, tokenAddress, claimAddress, timelock));
     }
+
+    function hashErc20SwapCommit(
+        bytes32 typehash,
+        bytes32 preimageHash,
+        uint256 amount,
+        address tokenAddress,
+        address claimAddress,
+        address refundAddress,
+        uint256 timelock
+    ) public pure returns (bytes32) {
+        return
+            keccak256(abi.encode(typehash, preimageHash, amount, tokenAddress, claimAddress, refundAddress, timelock));
+    }
 }

--- a/contracts/test/SigUtils.sol
+++ b/contracts/test/SigUtils.sol
@@ -34,6 +34,17 @@ contract SigUtils {
         return keccak256(abi.encode(typehash, preimageHash, amount, claimAddress, timelock));
     }
 
+    function hashEtherSwapCommit(
+        bytes32 typehash,
+        bytes32 preimageHash,
+        uint256 amount,
+        address claimAddress,
+        address refundAddress,
+        uint256 timelock
+    ) public pure returns (bytes32) {
+        return keccak256(abi.encode(typehash, preimageHash, amount, claimAddress, refundAddress, timelock));
+    }
+
     function hashErc20SwapClaim(
         bytes32 typehash,
         bytes32 preimage,


### PR DESCRIPTION
By specifying `bytes32(0)` as the preimage hash, funds can be locked before knowing the invoice to be paid by the swap. To claim the funds, the claimer must provide a signature (which includes a preimage hash) from the refund address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Commitment-based swaps with signature authorization from refund addresses for Ether and ERC20 flows.
  * Batch claiming of swaps (mixing commitment and normal entries).
  * Ability to specify explicit refund addresses when locking swaps.
  * Public API to verify commitment signatures.

* **Bug Fixes**
  * Hardened claim/refund validation and flow to prevent misuse and race conditions.

* **Tests**
  * Added tests for refund-address locks, commit claims, invalid signatures, and batch claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->