### PR TITLE
Convert package to ESM

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        node-version: [20, 22, 24, 25]
+        node-version: [20, 22, 24, 25, 26]
 
     runs-on: ${{ matrix.platform }}
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -67,4 +67,11 @@ export default [
       'no-restricted-imports': 'off',
     },
   },
+  {
+    files: ['**/*.cjs'],
+    languageOptions: {
+      sourceType: 'commonjs',
+      globals: { ...globals.node, ...globals.commonjs },
+    },
+  },
 ];

--- a/jest.resolver.cjs
+++ b/jest.resolver.cjs
@@ -1,12 +1,14 @@
 /**
- * Custom Jest resolver to handle ESM .js extension imports from @noble and @scure packages
+ * Custom Jest resolver to handle ESM .js extension imports.
+ * Strips .js for @noble/@scure packages and relative source imports
+ * (where the actual file is .ts and the .js is only for ESM compat).
  */
 module.exports = (path, options) => {
-  // Only strip .js extension for @noble and @scure packages
   const esmPackages = ['@noble/', '@scure/'];
   const isEsmPackage = esmPackages.some((pkg) => path.startsWith(pkg));
+  const isRelative = path.startsWith('./') || path.startsWith('../');
 
-  if (isEsmPackage && path.endsWith('.js')) {
+  if ((isEsmPackage || isRelative) && path.endsWith('.js')) {
     const strippedPath = path.slice(0, -3);
     try {
       return options.defaultResolver(strippedPath, options);

--- a/lib/ABIs.ts
+++ b/lib/ABIs.ts
@@ -1,7 +1,7 @@
-import ERC20ABI from '../out/ERC20.sol/ERC20.json';
-import ERC20SwapABI from '../out/ERC20Swap.sol/ERC20Swap.json';
-import EtherSwapABI from '../out/EtherSwap.sol/EtherSwap.json';
-import RouterABI from '../out/Router.sol/Router.json';
+import ERC20ABI from '../out/ERC20.sol/ERC20.json' with { type: 'json' };
+import ERC20SwapABI from '../out/ERC20Swap.sol/ERC20Swap.json' with { type: 'json' };
+import EtherSwapABI from '../out/EtherSwap.sol/EtherSwap.json' with { type: 'json' };
+import RouterABI from '../out/Router.sol/Router.json' with { type: 'json' };
 
 export const ContractABIs: {
   ERC20: unknown[];

--- a/lib/ABIs.ts
+++ b/lib/ABIs.ts
@@ -3,9 +3,14 @@ import ERC20SwapABI from '../out/ERC20Swap.sol/ERC20Swap.json';
 import EtherSwapABI from '../out/EtherSwap.sol/EtherSwap.json';
 import RouterABI from '../out/Router.sol/Router.json';
 
-export const ContractABIs = {
+export const ContractABIs: {
+  ERC20: unknown[];
+  ERC20Swap: unknown[];
+  EtherSwap: unknown[];
+  Router: unknown[];
+} = {
   ERC20: ERC20ABI.abi,
   ERC20Swap: ERC20SwapABI.abi,
   EtherSwap: EtherSwapABI.abi,
   Router: RouterABI.abi,
-} as const;
+};

--- a/lib/Boltz.ts
+++ b/lib/Boltz.ts
@@ -1,28 +1,28 @@
-import { targetFee } from './TargetFee';
-import { OutputType } from './consts/Enums';
-import Networks from './consts/Networks';
-import * as Types from './consts/Types';
-import type { ClaimDetails, RefundDetails } from './consts/Types';
-import * as Musig from './musig/Musig';
-import { constructClaimTransaction } from './swap/Claim';
-import { detectPreimage } from './swap/PreimageDetector';
-import { constructRefundTransaction } from './swap/Refund';
-import reverseSwapScript from './swap/ReverseSwapScript';
+import { targetFee } from './TargetFee.ts';
+import { OutputType } from './consts/Enums.ts';
+import Networks from './consts/Networks.ts';
+import * as Types from './consts/Types.ts';
+import type { ClaimDetails, RefundDetails } from './consts/Types.ts';
+import * as Musig from './musig/Musig.ts';
+import { constructClaimTransaction } from './swap/Claim.ts';
+import { detectPreimage } from './swap/PreimageDetector.ts';
+import { constructRefundTransaction } from './swap/Refund.ts';
+import reverseSwapScript from './swap/ReverseSwapScript.ts';
 import reverseSwapTree, {
   extractClaimPublicKeyFromReverseSwapTree,
   extractRefundPublicKeyFromReverseSwapTree,
-} from './swap/ReverseSwapTree';
-import * as Scripts from './swap/Scripts';
-import { detectSwap } from './swap/SwapDetector';
-import swapScript from './swap/SwapScript';
+} from './swap/ReverseSwapTree.ts';
+import * as Scripts from './swap/Scripts.ts';
+import { detectSwap } from './swap/SwapDetector.ts';
+import swapScript from './swap/SwapScript.ts';
 import swapTree, {
   extractClaimPublicKeyFromSwapTree,
   extractRefundPublicKeyFromSwapTree,
   fundingAddressTree,
-} from './swap/SwapTree';
-import { compareTrees } from './swap/SwapTreeCompare';
-import * as SwapTreeSerializer from './swap/SwapTreeSerializer';
-import * as TaprootUtils from './swap/TaprootUtils';
+} from './swap/SwapTree.ts';
+import { compareTrees } from './swap/SwapTreeCompare.ts';
+import * as SwapTreeSerializer from './swap/SwapTreeSerializer.ts';
+import * as TaprootUtils from './swap/TaprootUtils.ts';
 
 export type { ClaimDetails, RefundDetails };
 

--- a/lib/consts/Networks.ts
+++ b/lib/consts/Networks.ts
@@ -1,7 +1,14 @@
+import type { BTC_NETWORK } from '@scure/btc-signer/utils.js';
 import { NETWORK, TEST_NETWORK } from '@scure/btc-signer/utils.js';
 
-export default {
+const Networks: {
+  bitcoin: BTC_NETWORK;
+  testnet: BTC_NETWORK;
+  regtest: BTC_NETWORK;
+} = {
   bitcoin: NETWORK,
   testnet: TEST_NETWORK,
   regtest: { bech32: 'bcrt', pubKeyHash: 0x6f, scriptHash: 0xc4, wif: 0xef },
-} as const;
+};
+
+export default Networks;

--- a/lib/consts/Types.ts
+++ b/lib/consts/Types.ts
@@ -1,4 +1,4 @@
-import type { OutputType } from './Enums';
+import type { OutputType } from './Enums.ts';
 
 export type Error = {
   message: string;

--- a/lib/internal/bitcoinOps.ts
+++ b/lib/internal/bitcoinOps.ts
@@ -1,0 +1,9 @@
+import bitcoinOpsImport from '@boltz/bitcoin-ops';
+
+type Ops = typeof bitcoinOpsImport.default;
+
+const ops: Ops =
+  (bitcoinOpsImport as { default?: Ops }).default ??
+  (bitcoinOpsImport as unknown as Ops);
+
+export default ops;

--- a/lib/internal/bitcoinOps.ts
+++ b/lib/internal/bitcoinOps.ts
@@ -1,9 +1,0 @@
-import bitcoinOpsImport from '@boltz/bitcoin-ops';
-
-type Ops = typeof bitcoinOpsImport.default;
-
-const ops: Ops =
-  (bitcoinOpsImport as { default?: Ops }).default ??
-  (bitcoinOpsImport as unknown as Ops);
-
-export default ops;

--- a/lib/liquid/Utils.ts
+++ b/lib/liquid/Utils.ts
@@ -1,7 +1,7 @@
-import ops from '@boltz/bitcoin-ops';
 import { confidential, crypto, script } from 'liquidjs-lib';
 import type { TxOutput } from 'liquidjs-lib';
-import { confidentialLiquid } from './init';
+import ops from '../internal/bitcoinOps.ts';
+import { confidentialLiquid } from './init.ts';
 
 export const getOutputValue = (
   output: TxOutput & {

--- a/lib/liquid/Utils.ts
+++ b/lib/liquid/Utils.ts
@@ -1,6 +1,5 @@
-import { confidential, crypto, script } from 'liquidjs-lib';
+import { confidential, crypto, opcodes, script } from 'liquidjs-lib';
 import type { TxOutput } from 'liquidjs-lib';
-import ops from '../internal/bitcoinOps.ts';
 import { confidentialLiquid } from './init.ts';
 
 export const getOutputValue = (
@@ -32,13 +31,13 @@ export const getScriptIntrospectionValues = (
   }
 
   switch (dec[0]) {
-    case ops.OP_1:
+    case opcodes.OP_1:
       return {
         version: 1,
         script: getScriptIntrospectionWitnessScript(outputScript),
       };
 
-    case ops.OP_0:
+    case opcodes.OP_0:
       return {
         version: 0,
         script: getScriptIntrospectionWitnessScript(outputScript),

--- a/lib/liquid/consts/Networks.ts
+++ b/lib/liquid/consts/Networks.ts
@@ -1,5 +1,5 @@
 import { networks } from 'liquidjs-lib';
-import type { Network } from 'liquidjs-lib/src/networks';
+import type { Network } from 'liquidjs-lib/src/networks.js';
 
 const Networks: {
   liquidMainnet: Network;

--- a/lib/liquid/consts/Networks.ts
+++ b/lib/liquid/consts/Networks.ts
@@ -1,6 +1,11 @@
 import { networks } from 'liquidjs-lib';
+import type { Network } from 'liquidjs-lib/src/networks';
 
-const Networks = {
+const Networks: {
+  liquidMainnet: Network;
+  liquidTestnet: Network;
+  liquidRegtest: Network;
+} = {
   liquidMainnet: networks.liquid,
   liquidTestnet: networks.testnet,
   liquidRegtest: networks.regtest,

--- a/lib/liquid/consts/Ops.ts
+++ b/lib/liquid/consts/Ops.ts
@@ -1,6 +1,0 @@
-// Reference: https://github.com/ElementsProject/elements/blob/master/doc/tapscript_opcodes.md#new-opcodes-for-additional-functionality
-export default {
-  OP_INSPECTOUTPUTSCRIPTPUBKEY: 0xd1,
-  OP_INSPECTOUTPUTASSET: 0xce,
-  OP_INSPECTOUTPUTVALUE: 0xcf,
-};

--- a/lib/liquid/consts/Types.ts
+++ b/lib/liquid/consts/Types.ts
@@ -1,10 +1,10 @@
 import type { Transaction, TxOutput } from 'liquidjs-lib';
-import type { OutputType } from '../../consts/Enums';
+import type { OutputType } from '../../consts/Enums.ts';
 import type {
   FundingAddressTree,
   LiquidSwapTree,
   RefundDetails,
-} from '../../consts/Types';
+} from '../../consts/Types.ts';
 
 export type LiquidBaseRefundDetails = Omit<
   RefundDetails,

--- a/lib/liquid/index.ts
+++ b/lib/liquid/index.ts
@@ -1,16 +1,19 @@
-import { getOutputValue } from './Utils';
-import * as Utils from './Utils';
-import Networks from './consts/Networks';
-import ops from './consts/Ops';
-import type { LiquidClaimDetails, LiquidRefundDetails } from './consts/Types';
-import { init } from './init';
-import { constructClaimTransaction } from './swap/Claim';
-import { constructRefundTransaction } from './swap/Refund';
+import { getOutputValue } from './Utils.ts';
+import * as Utils from './Utils.ts';
+import Networks from './consts/Networks.ts';
+import ops from './consts/Ops.ts';
+import type {
+  LiquidClaimDetails,
+  LiquidRefundDetails,
+} from './consts/Types.ts';
+import { init } from './init.ts';
+import { constructClaimTransaction } from './swap/Claim.ts';
+import { constructRefundTransaction } from './swap/Refund.ts';
 import reverseSwapTree, {
   Feature,
   type FeatureOption,
-} from './swap/ReverseSwapTree';
-import * as TaprootUtils from './swap/TaprootUtils';
+} from './swap/ReverseSwapTree.ts';
+import * as TaprootUtils from './swap/TaprootUtils.ts';
 
 export type { FeatureOption, LiquidClaimDetails, LiquidRefundDetails };
 

--- a/lib/liquid/index.ts
+++ b/lib/liquid/index.ts
@@ -1,7 +1,6 @@
 import { getOutputValue } from './Utils.ts';
 import * as Utils from './Utils.ts';
 import Networks from './consts/Networks.ts';
-import ops from './consts/Ops.ts';
 import type {
   LiquidClaimDetails,
   LiquidRefundDetails,
@@ -18,7 +17,6 @@ import * as TaprootUtils from './swap/TaprootUtils.ts';
 export type { FeatureOption, LiquidClaimDetails, LiquidRefundDetails };
 
 export {
-  ops,
   Utils,
   Feature,
   Networks,

--- a/lib/liquid/init.ts
+++ b/lib/liquid/init.ts
@@ -4,7 +4,7 @@ import { type Secp256k1Interface, confidential } from 'liquidjs-lib';
 export let secp: Secp256k1ZKP;
 export let confidentialLiquid: confidential.Confidential;
 
-export const init = (zkp: Secp256k1ZKP) => {
+export const init = (zkp: Secp256k1ZKP): void => {
   secp = zkp;
   confidentialLiquid = new confidential.Confidential(
     secp as unknown as Secp256k1Interface,

--- a/lib/liquid/swap/Claim.ts
+++ b/lib/liquid/swap/Claim.ts
@@ -1,4 +1,3 @@
-import ops from '@boltz/bitcoin-ops';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { Script } from '@scure/btc-signer';
@@ -19,22 +18,23 @@ import {
   ZKPValidator,
   witnessStackToScriptWitness,
 } from 'liquidjs-lib';
-import type { Network } from 'liquidjs-lib/src/networks';
-import { OutputType } from '../../consts/Enums';
-import type { LiquidSwapTree } from '../../consts/Types';
+import type { Network } from 'liquidjs-lib/src/networks.js';
+import { OutputType } from '../../consts/Enums.ts';
+import type { LiquidSwapTree } from '../../consts/Types.ts';
+import ops from '../../internal/bitcoinOps.ts';
 import {
   getClaimLeaf,
   getTapLeaf,
   isRelevantTaprootOutput,
   signLegacy,
   validateInputs,
-} from '../../swap/Claim';
-import { toXOnly } from '../../swap/TaprootUtils';
-import { getOutputValue } from '../Utils';
-import Networks from '../consts/Networks';
-import type { LiquidClaimDetails } from '../consts/Types';
-import { secp } from '../init';
-import { createControlBlock, tapLeafHash, toHashTree } from './TaprootUtils';
+} from '../../swap/Claim.ts';
+import { toXOnly } from '../../swap/TaprootUtils.ts';
+import { getOutputValue } from '../Utils.ts';
+import Networks from '../consts/Networks.ts';
+import type { LiquidClaimDetails } from '../consts/Types.ts';
+import { secp } from '../init.ts';
+import { createControlBlock, tapLeafHash, toHashTree } from './TaprootUtils.ts';
 
 const dummyTaprootSignature = Buffer.alloc(64);
 

--- a/lib/liquid/swap/Claim.ts
+++ b/lib/liquid/swap/Claim.ts
@@ -16,12 +16,12 @@ import {
   Updater,
   ZKPGenerator,
   ZKPValidator,
+  opcodes,
   witnessStackToScriptWitness,
 } from 'liquidjs-lib';
 import type { Network } from 'liquidjs-lib/src/networks.js';
 import { OutputType } from '../../consts/Enums.ts';
 import type { LiquidSwapTree } from '../../consts/Types.ts';
-import ops from '../../internal/bitcoinOps.ts';
 import {
   getClaimLeaf,
   getTapLeaf,
@@ -178,7 +178,7 @@ export const constructClaimTransaction = (
           network.assetHash,
           // TODO: figure out flakiness with blinding 0 amount outputs
           1,
-          Buffer.of(ops.OP_RETURN),
+          Buffer.of(opcodes.OP_RETURN),
           Buffer.from(
             secp256k1.getPublicKey(secp256k1.utils.randomSecretKey()),
           ),

--- a/lib/liquid/swap/Refund.ts
+++ b/lib/liquid/swap/Refund.ts
@@ -1,8 +1,11 @@
 import type { Transaction } from 'liquidjs-lib';
-import type { Network } from 'liquidjs-lib/src/networks';
-import Networks from '../consts/Networks';
-import type { LiquidClaimDetails, LiquidRefundDetails } from '../consts/Types';
-import { constructClaimTransaction } from './Claim';
+import type { Network } from 'liquidjs-lib/src/networks.js';
+import Networks from '../consts/Networks.ts';
+import type {
+  LiquidClaimDetails,
+  LiquidRefundDetails,
+} from '../consts/Types.ts';
+import { constructClaimTransaction } from './Claim.ts';
 
 const dummyPreimage = new Uint8Array(0);
 

--- a/lib/liquid/swap/ReverseSwapTree.ts
+++ b/lib/liquid/swap/ReverseSwapTree.ts
@@ -1,14 +1,12 @@
 import { ripemd160 } from '@noble/hashes/legacy.js';
 import { hex } from '@scure/base';
-import { script } from 'liquidjs-lib';
+import { opcodes, script } from 'liquidjs-lib';
 import { reverseBuffer } from 'liquidjs-lib/src/bufferutils.js';
 import type { LiquidSwapTree, TapLeaf } from '../../consts/Types.ts';
-import ops from '../../internal/bitcoinOps.ts';
 import bitcoinReverseSwapTree from '../../swap/ReverseSwapTree.ts';
 import { TAP_LEAF_VERSION_LIQUID } from '../../swap/TaprootUtils.ts';
 import { assignTreeProbabilities, sortTree } from '../../swap/TreeSort.ts';
 import { getScriptIntrospectionValues } from '../Utils.ts';
-import liquidOps from '../consts/Ops.ts';
 
 enum Feature {
   ClaimCovenant,
@@ -38,32 +36,32 @@ const createClaimCovenantLeaf = (
   return {
     version: TAP_LEAF_VERSION_LIQUID,
     output: script.compile([
-      ops.OP_SIZE,
+      opcodes.OP_SIZE,
       script.number.encode(32),
-      ops.OP_EQUALVERIFY,
-      ops.OP_HASH160,
+      opcodes.OP_EQUALVERIFY,
+      opcodes.OP_HASH160,
       Buffer.from(ripemd160(preimageHash)),
-      ops.OP_EQUALVERIFY,
+      opcodes.OP_EQUALVERIFY,
 
       claimCovenantOutputIndex,
-      liquidOps.OP_INSPECTOUTPUTSCRIPTPUBKEY,
+      opcodes.OP_INSPECTOUTPUTSCRIPTPUBKEY,
       script.number.encode(userOutput.version),
-      ops.OP_EQUALVERIFY,
+      opcodes.OP_EQUALVERIFY,
       userOutput.script,
-      ops.OP_EQUALVERIFY,
+      opcodes.OP_EQUALVERIFY,
 
       claimCovenantOutputIndex,
-      liquidOps.OP_INSPECTOUTPUTASSET,
-      ops.OP_1,
-      ops.OP_EQUALVERIFY,
+      opcodes.OP_INSPECTOUTPUTASSET,
+      opcodes.OP_1,
+      opcodes.OP_EQUALVERIFY,
       reverseBuffer(Buffer.from(hex.decode(assetHash))),
-      ops.OP_EQUALVERIFY,
+      opcodes.OP_EQUALVERIFY,
 
       claimCovenantOutputIndex,
-      liquidOps.OP_INSPECTOUTPUTVALUE,
-      ops.OP_DROP,
+      opcodes.OP_INSPECTOUTPUTVALUE,
+      opcodes.OP_DROP,
       amountBuffer,
-      ops.OP_EQUAL,
+      opcodes.OP_EQUAL,
     ]),
   };
 };

--- a/lib/liquid/swap/ReverseSwapTree.ts
+++ b/lib/liquid/swap/ReverseSwapTree.ts
@@ -1,14 +1,14 @@
-import ops from '@boltz/bitcoin-ops';
 import { ripemd160 } from '@noble/hashes/legacy.js';
 import { hex } from '@scure/base';
 import { script } from 'liquidjs-lib';
-import { reverseBuffer } from 'liquidjs-lib/src/bufferutils';
-import type { LiquidSwapTree, TapLeaf } from '../../consts/Types';
-import bitcoinReverseSwapTree from '../../swap/ReverseSwapTree';
-import { TAP_LEAF_VERSION_LIQUID } from '../../swap/TaprootUtils';
-import { assignTreeProbabilities, sortTree } from '../../swap/TreeSort';
-import { getScriptIntrospectionValues } from '../Utils';
-import liquidOps from '../consts/Ops';
+import { reverseBuffer } from 'liquidjs-lib/src/bufferutils.js';
+import type { LiquidSwapTree, TapLeaf } from '../../consts/Types.ts';
+import ops from '../../internal/bitcoinOps.ts';
+import bitcoinReverseSwapTree from '../../swap/ReverseSwapTree.ts';
+import { TAP_LEAF_VERSION_LIQUID } from '../../swap/TaprootUtils.ts';
+import { assignTreeProbabilities, sortTree } from '../../swap/TreeSort.ts';
+import { getScriptIntrospectionValues } from '../Utils.ts';
+import liquidOps from '../consts/Ops.ts';
 
 enum Feature {
   ClaimCovenant,

--- a/lib/liquid/swap/TaprootUtils.ts
+++ b/lib/liquid/swap/TaprootUtils.ts
@@ -1,17 +1,17 @@
 import { hex } from '@scure/base';
 import type { TxOutput } from 'liquidjs-lib';
 import { Transaction } from 'liquidjs-lib';
-import type { HashTree } from 'liquidjs-lib/src/bip341';
+import type { HashTree } from 'liquidjs-lib/src/bip341.js';
 import {
   findScriptPath as liquidFindScriptPath,
   tapLeafHash as liquidTapLeafHash,
-} from 'liquidjs-lib/src/bip341';
-import { taggedHash } from 'liquidjs-lib/src/crypto';
-import type { Network } from 'liquidjs-lib/src/networks';
-import type { TapLeaf, TapTree } from '../../consts/Types';
-import type { MusigKeyAgg } from '../../musig/Musig';
-import { toXOnly } from '../../swap/TaprootUtils';
-import { secp } from '../init';
+} from 'liquidjs-lib/src/bip341.js';
+import { taggedHash } from 'liquidjs-lib/src/crypto.js';
+import type { Network } from 'liquidjs-lib/src/networks.js';
+import type { TapLeaf, TapTree } from '../../consts/Types.ts';
+import type { MusigKeyAgg } from '../../musig/Musig.ts';
+import { toXOnly } from '../../swap/TaprootUtils.ts';
+import { secp } from '../init.ts';
 
 const convertLeaf = (leaf: TapLeaf) => ({
   version: leaf.version,

--- a/lib/liquid/swap/TaprootUtils.ts
+++ b/lib/liquid/swap/TaprootUtils.ts
@@ -39,13 +39,13 @@ export const hashForWitnessV1 = (
   );
 };
 
-export const tapLeafHash = (leaf: TapLeaf) =>
+export const tapLeafHash = (leaf: TapLeaf): Buffer =>
   liquidTapLeafHash(convertLeaf(leaf));
 
-export const tapBranchHash = (a: Buffer, b: Buffer) =>
+export const tapBranchHash = (a: Buffer, b: Buffer): Buffer =>
   taggedHash('TapBranch/elements', Buffer.concat([a, b]));
 
-export const tapTweakHash = (publicKey: Buffer, tweak: Buffer) =>
+export const tapTweakHash = (publicKey: Buffer, tweak: Buffer): Buffer =>
   taggedHash('TapTweak/elements', Buffer.concat([toXOnly(publicKey), tweak]));
 
 export function toHashTree(scriptTree: TapTree): HashTree {

--- a/lib/swap/Claim.ts
+++ b/lib/swap/Claim.ts
@@ -2,15 +2,15 @@ import { sha256 } from '@noble/hashes/sha2.js';
 import { concatBytes } from '@noble/hashes/utils.js';
 import { Script, SigHash, Transaction } from '@scure/btc-signer';
 import { signECDSA, signSchnorr } from '@scure/btc-signer/utils.js';
-import { OutputType } from '../Boltz';
-import { Errors } from '../consts/Errors';
+import { OutputType } from '../Boltz.ts';
+import { Errors } from '../consts/Errors.ts';
 import {
   type ClaimDetails,
   type FundingAddressTree,
   type SwapTree,
   isSwapTree,
-} from '../consts/Types';
-import { createControlBlock, taprootHashTree } from './TaprootUtils';
+} from '../consts/Types.ts';
+import { createControlBlock, taprootHashTree } from './TaprootUtils.ts';
 
 const LEGACY_SIGHASH = SigHash.ALL;
 const DUMMY_TAPROOT_SIGNATURE = new Uint8Array(64);

--- a/lib/swap/Claim.ts
+++ b/lib/swap/Claim.ts
@@ -17,14 +17,14 @@ const DUMMY_TAPROOT_SIGNATURE = new Uint8Array(64);
 
 export const isRelevantTaprootOutput = (
   utxo: Pick<ClaimDetails, 'type' | 'cooperative'>,
-) => utxo.type === OutputType.Taproot && utxo.cooperative !== true;
+): boolean => utxo.type === OutputType.Taproot && utxo.cooperative !== true;
 
 export const validateInputs = (
   utxos: Pick<
     ClaimDetails,
     'type' | 'redeemScript' | 'swapTree' | 'internalKey'
   >[],
-) => {
+): void => {
   if (
     utxos
       .filter((utxo) => utxo.type !== OutputType.Taproot)
@@ -67,7 +67,7 @@ export const constructClaimTransaction = (
   isRbf = true,
   timeoutBlockHeight?: number,
   isRefund = false,
-) => {
+): Transaction => {
   validateInputs(utxos);
 
   const tx = new Transaction({
@@ -186,7 +186,10 @@ export const constructClaimTransaction = (
   return tx;
 };
 
-export const signLegacy = (hash: Uint8Array, privateKey: Uint8Array) => {
+export const signLegacy = (
+  hash: Uint8Array,
+  privateKey: Uint8Array,
+): Uint8Array => {
   return concatBytes(
     signECDSA(hash, privateKey, true),
     new Uint8Array([LEGACY_SIGHASH]),

--- a/lib/swap/Refund.ts
+++ b/lib/swap/Refund.ts
@@ -1,6 +1,6 @@
 import type { Transaction } from '@scure/btc-signer';
-import type { ClaimDetails, RefundDetails } from '../consts/Types';
-import { constructClaimTransaction } from './Claim';
+import type { ClaimDetails, RefundDetails } from '../consts/Types.ts';
+import { constructClaimTransaction } from './Claim.ts';
 
 const dummyPreimage = new Uint8Array(0);
 

--- a/lib/swap/ReverseSwapTree.ts
+++ b/lib/swap/ReverseSwapTree.ts
@@ -1,11 +1,11 @@
 import { ripemd160 } from '@noble/hashes/legacy.js';
 import { Script } from '@scure/btc-signer';
-import type { SwapTree } from '../consts/Types';
+import type { SwapTree } from '../consts/Types.ts';
 import {
   createRefundLeaf,
   extractRefundPublicKeyFromSwapTree,
-} from './SwapTree';
-import { createLeaf, swapLeafsToTree, toXOnly } from './TaprootUtils';
+} from './SwapTree.ts';
+import { createLeaf, swapLeafsToTree, toXOnly } from './TaprootUtils.ts';
 
 export const extractClaimPublicKeyFromReverseSwapTree = (
   swapTree: SwapTree,

--- a/lib/swap/Scripts.ts
+++ b/lib/swap/Scripts.ts
@@ -1,8 +1,8 @@
 import { sha256 } from '@noble/hashes/sha2.js';
 import { Script } from '@scure/btc-signer';
 import { hash160 } from '@scure/btc-signer/utils.js';
-import { OutputType } from '../consts/Enums';
-import { toXOnly } from './TaprootUtils';
+import { OutputType } from '../consts/Enums.ts';
+import { toXOnly } from './TaprootUtils.ts';
 
 export const p2trOutput = (publicKey: Uint8Array): Uint8Array => {
   return Script.encode(['OP_1', toXOnly(publicKey)]);

--- a/lib/swap/SwapDetector.ts
+++ b/lib/swap/SwapDetector.ts
@@ -1,13 +1,13 @@
 import { Transaction } from '@scure/btc-signer';
 import type { TransactionOutput } from '@scure/btc-signer/psbt.js';
 import { equalBytes } from '@scure/btc-signer/utils.js';
-import { OutputType } from '../consts/Enums';
+import { OutputType } from '../consts/Enums.ts';
 import {
   p2shOutput,
   p2shP2wshOutput,
   p2trOutput,
   p2wshOutput,
-} from './Scripts';
+} from './Scripts.ts';
 
 type LiquidTxOutput = {
   script: Buffer;

--- a/lib/swap/SwapTree.ts
+++ b/lib/swap/SwapTree.ts
@@ -1,7 +1,7 @@
 import { ripemd160 } from '@noble/hashes/legacy.js';
 import { Script } from '@scure/btc-signer';
-import type { FundingAddressTree, SwapTree, TapLeaf } from '../consts/Types';
-import { createLeaf, swapLeafsToTree, toXOnly } from './TaprootUtils';
+import type { FundingAddressTree, SwapTree, TapLeaf } from '../consts/Types.ts';
+import { createLeaf, swapLeafsToTree, toXOnly } from './TaprootUtils.ts';
 
 export const createRefundLeaf = (
   isLiquid: boolean,

--- a/lib/swap/SwapTree.ts
+++ b/lib/swap/SwapTree.ts
@@ -1,13 +1,13 @@
 import { ripemd160 } from '@noble/hashes/legacy.js';
 import { Script } from '@scure/btc-signer';
-import type { FundingAddressTree, SwapTree } from '../consts/Types';
+import type { FundingAddressTree, SwapTree, TapLeaf } from '../consts/Types';
 import { createLeaf, swapLeafsToTree, toXOnly } from './TaprootUtils';
 
 export const createRefundLeaf = (
   isLiquid: boolean,
   refundPublicKey: Uint8Array,
   timeoutBlockHeight: number,
-) =>
+): TapLeaf =>
   createLeaf(isLiquid, [
     toXOnly(refundPublicKey),
     'CHECKSIGVERIFY',

--- a/lib/swap/SwapTreeCompare.ts
+++ b/lib/swap/SwapTreeCompare.ts
@@ -1,5 +1,5 @@
 import { equalBytes } from '@scure/btc-signer/utils.js';
-import type { SwapTree, TapLeaf, TapTree } from '../consts/Types';
+import type { SwapTree, TapLeaf, TapTree } from '../consts/Types.ts';
 
 const compareLeaf = (leaf: TapLeaf, compareLeaf: TapLeaf) =>
   leaf.version === compareLeaf.version &&

--- a/lib/swap/SwapTreeSerializer.ts
+++ b/lib/swap/SwapTreeSerializer.ts
@@ -4,8 +4,8 @@ import type {
   LiquidSwapTree,
   SwapTree,
   TapLeaf,
-} from '../consts/Types';
-import { assignTreeProbabilities, sortTree } from './TreeSort';
+} from '../consts/Types.ts';
+import { assignTreeProbabilities, sortTree } from './TreeSort.ts';
 
 type SerializedLeaf = {
   version: number;

--- a/lib/swap/TaprootUtils.ts
+++ b/lib/swap/TaprootUtils.ts
@@ -16,8 +16,8 @@ import {
   equalBytes,
   taprootTweakPubkey,
 } from '@scure/btc-signer/utils.js';
-import type { TapLeaf, TapTree } from '../consts/Types';
-import type { MusigKeyAgg } from '../musig/Musig';
+import type { TapLeaf, TapTree } from '../consts/Types.ts';
+import type { MusigKeyAgg } from '../musig/Musig.ts';
 
 export const TAP_LEAF_VERSION_LIQUID = 196;
 

--- a/lib/swap/TreeSort.ts
+++ b/lib/swap/TreeSort.ts
@@ -1,4 +1,4 @@
-import type { LiquidSwapTree } from '../consts/Types';
+import type { LiquidSwapTree } from '../consts/Types.ts';
 
 type ProbabilityNode<T> = { probability: number; value: T };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@trivago/prettier-plugin-sort-imports": "^6.0.2",
         "@types/jest": "^30.0.0",
         "@types/node": "^25.6.0",
-        "@types/ws": "^8.18.1",
         "eslint": "^9.39.4",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jest": "^29.15.2",
@@ -33,8 +32,7 @@
         "prettier": "^3.8.3",
         "slip77": "^0.2.0",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.59.1",
-        "ws": "^8.20.0"
+        "typescript-eslint": "^8.59.1"
       },
       "engines": {
         "node": ">=20.10"
@@ -618,9 +616,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -638,9 +633,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -658,9 +650,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -678,9 +667,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1980,9 +1966,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2000,9 +1983,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2020,9 +2000,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2040,9 +2017,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2060,9 +2034,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2080,9 +2051,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2388,16 +2356,6 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -9344,28 +9302,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boltz-core",
-  "version": "4.0.5",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boltz-core",
-      "version": "4.0.5",
+      "version": "5.0.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@boltz/bitcoin-ops": "^2.0.0",
@@ -38,7 +38,7 @@
         "ws": "^8.20.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20.10"
       },
       "peerDependencies": {
         "@vulpemventures/secp256k1-zkp": "^3.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "5.0.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@boltz/bitcoin-ops": "^2.0.0",
         "@noble/curves": "^2.2.0",
         "@noble/hashes": "^2.2.0",
         "@scure/base": "^2.2.0",
@@ -724,11 +723,6 @@
       "engines": {
         "node": ">=14.21.3"
       }
-    },
-    "node_modules/@boltz/bitcoin-ops": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@boltz/bitcoin-ops/-/bitcoin-ops-2.0.0.tgz",
-      "integrity": "sha512-AM7vFNwSD7B4XI6yeRKccWbbD/lvwoFr8U3pqhzryBQo4uMkYe5V3/kMVnml4SNuxzyqdIFu4ur3TId02sC33A=="
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.6.0",
-    "@types/ws": "^8.18.1",
     "eslint": "^9.39.4",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jest": "^29.15.2",
@@ -93,8 +92,7 @@
     "prettier": "^3.8.3",
     "slip77": "^0.2.0",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.59.1",
-    "ws": "^8.20.0"
+    "typescript-eslint": "^8.59.1"
   },
   "peerDependencies": {
     "@vulpemventures/secp256k1-zkp": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "dist/**/!(tsconfig.tsbuildinfo)"
   ],
   "dependencies": {
-    "@boltz/bitcoin-ops": "^2.0.0",
     "@noble/curves": "^2.2.0",
     "@noble/hashes": "^2.2.0",
     "@scure/base": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,18 +1,17 @@
 {
   "name": "boltz-core",
-  "version": "4.0.5",
+  "version": "5.0.0",
   "description": "Core library of Boltz",
+  "type": "module",
   "main": "dist/lib/Boltz.js",
   "types": "dist/lib/Boltz.d.ts",
   "exports": {
     ".": {
       "types": "./dist/lib/Boltz.d.ts",
-      "require": "./dist/lib/Boltz.js",
       "default": "./dist/lib/Boltz.js"
     },
     "./liquid": {
       "types": "./dist/lib/liquid/index.d.ts",
-      "require": "./dist/lib/liquid/index.js",
       "default": "./dist/lib/liquid/index.js"
     },
     "./out/*": "./out/*",
@@ -51,7 +50,7 @@
     "url": "git+https://github.com/BoltzExchange/boltz-core.git"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=20.10"
   },
   "files": [
     "LICENSE",

--- a/test/integration/Utils.ts
+++ b/test/integration/Utils.ts
@@ -4,7 +4,6 @@ import { hex } from '@scure/base';
 import { Address, OutScript, Transaction } from '@scure/btc-signer';
 import type { TransactionOutput } from '@scure/btc-signer/psbt.js';
 import { hash160 } from '@scure/btc-signer/utils.js';
-import initZkp, { type Secp256k1ZKP } from '@vulpemventures/secp256k1-zkp';
 import type { TxOutput as LiquidTxOutput } from 'liquidjs-lib';
 import {
   Transaction as LiquidTransaction,
@@ -19,32 +18,36 @@ import {
   constructRefundTransaction,
   detectSwap,
   targetFee,
-} from '../../lib/Boltz';
+} from '../../lib/Boltz.ts';
 import type {
   ClaimDetails,
   RefundDetails,
   SwapTree,
-} from '../../lib/consts/Types';
-import type { LiquidClaimDetails, LiquidRefundDetails } from '../../lib/liquid';
+} from '../../lib/consts/Types.ts';
+import type {
+  LiquidClaimDetails,
+  LiquidRefundDetails,
+} from '../../lib/liquid/index.ts';
 import {
   Networks as LiquidNetworks,
   constructClaimTransaction as liquidConstructClaimTransaction,
   constructRefundTransaction as liquidConstructRefundTransaction,
-} from '../../lib/liquid';
-import { tweakMusig as liquidTweakMusig } from '../../lib/liquid/swap/TaprootUtils';
-import * as Musig from '../../lib/musig/Musig';
-import type { MusigKeyAgg } from '../../lib/musig/Musig';
+} from '../../lib/liquid/index.ts';
+import { tweakMusig as liquidTweakMusig } from '../../lib/liquid/swap/TaprootUtils.ts';
+import * as Musig from '../../lib/musig/Musig.ts';
+import type { MusigKeyAgg } from '../../lib/musig/Musig.ts';
 import {
   outputFunctionForType,
   p2trOutput,
   p2wpkhOutput,
-} from '../../lib/swap/Scripts';
-import type swapScript from '../../lib/swap/SwapScript';
-import type swapTree from '../../lib/swap/SwapTree';
-import { tweakMusig } from '../../lib/swap/TaprootUtils';
-import { slip77 } from '../unit/Utils';
-import ElementsClient from './liquid/utils/ElementsClient';
-import ChainClient from './utils/ChainClient';
+} from '../../lib/swap/Scripts.ts';
+import type swapScript from '../../lib/swap/SwapScript.ts';
+import type swapTree from '../../lib/swap/SwapTree.ts';
+import { tweakMusig } from '../../lib/swap/TaprootUtils.ts';
+import { slip77 } from '../unit/Utils.ts';
+import initZkp, { type Secp256k1ZKP } from '../zkp.ts';
+import ElementsClient from './liquid/utils/ElementsClient.ts';
+import ChainClient from './utils/ChainClient.ts';
 
 export const bitcoinClient = new ChainClient({
   host: '127.0.0.1',

--- a/test/integration/fundingAddressTree/FundingAddressTreeRefund.spec.ts
+++ b/test/integration/fundingAddressTree/FundingAddressTreeRefund.spec.ts
@@ -2,16 +2,20 @@ import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { hex } from '@scure/base';
 import { Transaction } from '@scure/btc-signer';
 import { taprootTweakPubkey } from '@scure/btc-signer/utils.js';
-import { OutputType, detectSwap, fundingAddressTree } from '../../../lib/Boltz';
-import type { RefundDetails } from '../../../lib/consts/Types';
-import { p2trOutput } from '../../../lib/swap/Scripts';
-import { taprootHashTree, toXOnly } from '../../../lib/swap/TaprootUtils';
+import {
+  OutputType,
+  detectSwap,
+  fundingAddressTree,
+} from '../../../lib/Boltz.ts';
+import type { RefundDetails } from '../../../lib/consts/Types.ts';
+import { p2trOutput } from '../../../lib/swap/Scripts.ts';
+import { taprootHashTree, toXOnly } from '../../../lib/swap/TaprootUtils.ts';
 import {
   bitcoinClient,
   encodeAddress,
   generateKeys,
   refundSwap,
-} from '../Utils';
+} from '../Utils.ts';
 
 const createFundingAddressOutput = async (
   timeoutBlockHeight: number,

--- a/test/integration/liquid/Utils.spec.ts
+++ b/test/integration/liquid/Utils.spec.ts
@@ -1,7 +1,7 @@
-import zkp from '@vulpemventures/secp256k1-zkp';
 import { Transaction, address } from 'liquidjs-lib';
-import { getOutputValue, init } from '../../../lib/liquid';
-import { elementsClient } from '../Utils';
+import { getOutputValue, init } from '../../../lib/liquid/index.ts';
+import zkp from '../../zkp.ts';
+import { elementsClient } from '../Utils.ts';
 
 describe('Liquid Utils', () => {
   beforeAll(async () => {

--- a/test/integration/liquid/fundingAddressTree/FundingAddressTreeRefund.spec.ts
+++ b/test/integration/liquid/fundingAddressTree/FundingAddressTreeRefund.spec.ts
@@ -1,22 +1,22 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js';
-import zkp, { type Secp256k1ZKP } from '@vulpemventures/secp256k1-zkp';
 import { Transaction, address } from 'liquidjs-lib';
-import { detectSwap, fundingAddressTree } from '../../../../lib/Boltz';
-import { OutputType } from '../../../../lib/consts/Enums';
-import type { FundingAddressTree } from '../../../../lib/consts/Types';
+import { detectSwap, fundingAddressTree } from '../../../../lib/Boltz.ts';
+import { OutputType } from '../../../../lib/consts/Enums.ts';
+import type { FundingAddressTree } from '../../../../lib/consts/Types.ts';
 import {
   Networks as LiquidNetworks,
   type LiquidRefundDetails,
   init,
-} from '../../../../lib/liquid';
-import { secp } from '../../../../lib/liquid/init';
+} from '../../../../lib/liquid/index.ts';
+import { secp } from '../../../../lib/liquid/init.ts';
 import {
   tapTweakHash,
   toHashTree,
-} from '../../../../lib/liquid/swap/TaprootUtils';
-import { p2trOutput } from '../../../../lib/swap/Scripts';
-import { toXOnly } from '../../../../lib/swap/TaprootUtils';
-import { slip77 } from '../../../unit/Utils';
+} from '../../../../lib/liquid/swap/TaprootUtils.ts';
+import { p2trOutput } from '../../../../lib/swap/Scripts.ts';
+import { toXOnly } from '../../../../lib/swap/TaprootUtils.ts';
+import { slip77 } from '../../../unit/Utils.ts';
+import zkp, { type Secp256k1ZKP } from '../../../zkp.ts';
 import {
   blindWitnessAddress,
   destinationOutput,
@@ -24,7 +24,7 @@ import {
   generateKeys,
   refundSwap,
   init as utilsInit,
-} from '../../Utils';
+} from '../../Utils.ts';
 
 let secpZkp: Secp256k1ZKP;
 

--- a/test/integration/liquid/reverseSwapTree/ReverseSwapTreeCovenantClaim.spec.ts
+++ b/test/integration/liquid/reverseSwapTree/ReverseSwapTreeCovenantClaim.spec.ts
@@ -1,31 +1,31 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { sha256 } from '@noble/hashes/sha2.js';
-import zkp from '@vulpemventures/secp256k1-zkp';
 import { Transaction, address, networks } from 'liquidjs-lib';
 import { randomBytes } from 'node:crypto';
-import { OutputType } from '../../../../lib/consts/Enums';
-import type { LiquidClaimDetails } from '../../../../lib/liquid';
+import { OutputType } from '../../../../lib/consts/Enums.ts';
+import type { LiquidClaimDetails } from '../../../../lib/liquid/index.ts';
 import {
   constructClaimTransaction,
   constructRefundTransaction,
   init,
-} from '../../../../lib/liquid';
+} from '../../../../lib/liquid/index.ts';
 import liquidReverseSwapTree, {
   Feature,
-} from '../../../../lib/liquid/swap/ReverseSwapTree';
+} from '../../../../lib/liquid/swap/ReverseSwapTree.ts';
 import {
   hashForWitnessV1,
   tweakMusig,
-} from '../../../../lib/liquid/swap/TaprootUtils';
-import * as Musig from '../../../../lib/musig/Musig';
-import { p2trOutput, p2wshOutput } from '../../../../lib/swap/Scripts';
-import { detectSwap } from '../../../../lib/swap/SwapDetector';
+} from '../../../../lib/liquid/swap/TaprootUtils.ts';
+import * as Musig from '../../../../lib/musig/Musig.ts';
+import { p2trOutput, p2wshOutput } from '../../../../lib/swap/Scripts.ts';
+import { detectSwap } from '../../../../lib/swap/SwapDetector.ts';
+import zkp from '../../../zkp.ts';
 import {
   blindWitnessAddress,
   elementsClient,
   init as utilsInit,
-} from '../../Utils';
-import { AddressType } from '../../utils/ChainClient';
+} from '../../Utils.ts';
+import { AddressType } from '../../utils/ChainClient.ts';
 
 describe.each`
   shouldBlind

--- a/test/integration/liquid/swapTree/ExplicitOutputWithNonce.spec.ts
+++ b/test/integration/liquid/swapTree/ExplicitOutputWithNonce.spec.ts
@@ -2,15 +2,18 @@ import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { signSchnorr } from '@scure/btc-signer/utils.js';
 import type { Secp256k1ZKP } from '@vulpemventures/secp256k1-zkp';
-import zkp from '@vulpemventures/secp256k1-zkp';
 import { Transaction, address, confidential, networks } from 'liquidjs-lib';
 import { randomBytes } from 'node:crypto';
-import { Musig, OutputType } from '../../../../lib/Boltz';
-import { constructRefundTransaction, init } from '../../../../lib/liquid';
-import { tweakMusig } from '../../../../lib/liquid/swap/TaprootUtils';
-import { p2trOutput } from '../../../../lib/swap/Scripts';
-import swapTree from '../../../../lib/swap/SwapTree';
-import { elementsClient, generateKeys } from '../../Utils';
+import { Musig, OutputType } from '../../../../lib/Boltz.ts';
+import {
+  constructRefundTransaction,
+  init,
+} from '../../../../lib/liquid/index.ts';
+import { tweakMusig } from '../../../../lib/liquid/swap/TaprootUtils.ts';
+import { p2trOutput } from '../../../../lib/swap/Scripts.ts';
+import swapTree from '../../../../lib/swap/SwapTree.ts';
+import zkp from '../../../zkp.ts';
+import { elementsClient, generateKeys } from '../../Utils.ts';
 
 describe('ExplicitOutputWithNonce', () => {
   let secp: Secp256k1ZKP;

--- a/test/integration/liquid/swapTree/SwapTreeClaim.spec.ts
+++ b/test/integration/liquid/swapTree/SwapTreeClaim.spec.ts
@@ -1,25 +1,25 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import type { Secp256k1ZKP } from '@vulpemventures/secp256k1-zkp';
-import zkp from '@vulpemventures/secp256k1-zkp';
 import { randomBytes } from 'node:crypto';
-import { Musig, OutputType } from '../../../../lib/Boltz';
-import type { LiquidClaimDetails } from '../../../../lib/liquid';
+import { Musig, OutputType } from '../../../../lib/Boltz.ts';
+import type { LiquidClaimDetails } from '../../../../lib/liquid/index.ts';
 import {
   Networks,
   constructClaimTransaction,
   init,
-} from '../../../../lib/liquid';
-import { hashForWitnessV1 } from '../../../../lib/liquid/swap/TaprootUtils';
-import reverseSwapTree from '../../../../lib/swap/ReverseSwapTree';
-import swapTree from '../../../../lib/swap/SwapTree';
-import { slip77 } from '../../../unit/Utils';
+} from '../../../../lib/liquid/index.ts';
+import { hashForWitnessV1 } from '../../../../lib/liquid/swap/TaprootUtils.ts';
+import reverseSwapTree from '../../../../lib/swap/ReverseSwapTree.ts';
+import swapTree from '../../../../lib/swap/SwapTree.ts';
+import { slip77 } from '../../../unit/Utils.ts';
+import zkp from '../../../zkp.ts';
 import {
   claimSwap,
   createSwapOutput,
   destinationOutput,
   elementsClient,
   init as utilsInit,
-} from '../../Utils';
+} from '../../Utils.ts';
 
 let secpZkp: Secp256k1ZKP;
 

--- a/test/integration/liquid/swapTree/SwapTreeRefund.spec.ts
+++ b/test/integration/liquid/swapTree/SwapTreeRefund.spec.ts
@@ -1,18 +1,18 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js';
-import zkp, { type Secp256k1ZKP } from '@vulpemventures/secp256k1-zkp';
-import { OutputType } from '../../../../lib/consts/Enums';
-import type { LiquidClaimDetails } from '../../../../lib/liquid';
-import { init } from '../../../../lib/liquid';
-import reverseSwapTree from '../../../../lib/swap/ReverseSwapTree';
-import swapTree from '../../../../lib/swap/SwapTree';
-import { slip77 } from '../../../unit/Utils';
+import { OutputType } from '../../../../lib/consts/Enums.ts';
+import type { LiquidClaimDetails } from '../../../../lib/liquid/index.ts';
+import { init } from '../../../../lib/liquid/index.ts';
+import reverseSwapTree from '../../../../lib/swap/ReverseSwapTree.ts';
+import swapTree from '../../../../lib/swap/SwapTree.ts';
+import { slip77 } from '../../../unit/Utils.ts';
+import zkp, { type Secp256k1ZKP } from '../../../zkp.ts';
 import {
   createSwapOutput,
   destinationOutput,
   elementsClient,
   refundSwap,
   init as utilsInit,
-} from '../../Utils';
+} from '../../Utils.ts';
 
 let secpZkp: Secp256k1ZKP;
 

--- a/test/integration/liquid/swapscript/SwapScriptClaim.spec.ts
+++ b/test/integration/liquid/swapscript/SwapScriptClaim.spec.ts
@@ -1,16 +1,16 @@
-import zkp, { type Secp256k1ZKP } from '@vulpemventures/secp256k1-zkp';
-import { reverseSwapScript, swapScript } from '../../../../lib/Boltz';
-import { OutputType } from '../../../../lib/consts/Enums';
-import type { LiquidClaimDetails } from '../../../../lib/liquid';
-import { init } from '../../../../lib/liquid';
-import { slip77 } from '../../../unit/Utils';
+import { reverseSwapScript, swapScript } from '../../../../lib/Boltz.ts';
+import { OutputType } from '../../../../lib/consts/Enums.ts';
+import type { LiquidClaimDetails } from '../../../../lib/liquid/index.ts';
+import { init } from '../../../../lib/liquid/index.ts';
+import { slip77 } from '../../../unit/Utils.ts';
+import zkp, { type Secp256k1ZKP } from '../../../zkp.ts';
 import {
   claimSwap,
   createSwapOutput,
   destinationOutput,
   elementsClient,
   init as utilsInit,
-} from '../../Utils';
+} from '../../Utils.ts';
 
 describe.each`
   script               | name                   | swapName

--- a/test/integration/liquid/swapscript/SwapScriptRefund.spec.ts
+++ b/test/integration/liquid/swapscript/SwapScriptRefund.spec.ts
@@ -1,16 +1,16 @@
-import zkp, { type Secp256k1ZKP } from '@vulpemventures/secp256k1-zkp';
-import { reverseSwapScript, swapScript } from '../../../../lib/Boltz';
-import { OutputType } from '../../../../lib/consts/Enums';
-import type { LiquidClaimDetails } from '../../../../lib/liquid';
-import { init } from '../../../../lib/liquid';
-import { slip77 } from '../../../unit/Utils';
+import { reverseSwapScript, swapScript } from '../../../../lib/Boltz.ts';
+import { OutputType } from '../../../../lib/consts/Enums.ts';
+import type { LiquidClaimDetails } from '../../../../lib/liquid/index.ts';
+import { init } from '../../../../lib/liquid/index.ts';
+import { slip77 } from '../../../unit/Utils.ts';
+import zkp, { type Secp256k1ZKP } from '../../../zkp.ts';
 import {
   createSwapOutput,
   destinationOutput,
   elementsClient,
   refundSwap,
   init as utilsInit,
-} from '../../Utils';
+} from '../../Utils.ts';
 
 describe.each`
   script               | name                   | swapName

--- a/test/integration/liquid/utils/ElementsClient.ts
+++ b/test/integration/liquid/utils/ElementsClient.ts
@@ -1,5 +1,5 @@
-import type { AddressType } from '../../utils/ChainClient';
-import ChainClient from '../../utils/ChainClient';
+import type { AddressType } from '../../utils/ChainClient.ts';
+import ChainClient from '../../utils/ChainClient.ts';
 
 enum LiquidAddressType {
   Blech32 = 'blech32',

--- a/test/integration/musig/Musig.spec.ts
+++ b/test/integration/musig/Musig.spec.ts
@@ -2,10 +2,10 @@ import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { hex } from '@scure/base';
 import { Address, OutScript, SigHash, Transaction } from '@scure/btc-signer';
 import { equalBytes } from '@scure/btc-signer/utils.js';
-import Networks from '../../../lib/consts/Networks';
-import * as Musig from '../../../lib/musig/Musig';
-import { p2trOutput } from '../../../lib/swap/Scripts';
-import { bitcoinClient, encodeAddress } from '../Utils';
+import Networks from '../../../lib/consts/Networks.ts';
+import * as Musig from '../../../lib/musig/Musig.ts';
+import { p2trOutput } from '../../../lib/swap/Scripts.ts';
+import { bitcoinClient, encodeAddress } from '../Utils.ts';
 
 describe('Musig', () => {
   beforeAll(async () => {

--- a/test/integration/reverseSwapTree/ReverseSwapTreeClaim.spec.ts
+++ b/test/integration/reverseSwapTree/ReverseSwapTreeClaim.spec.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from 'node:crypto';
-import { OutputType } from '../../../lib/consts/Enums';
-import reverseSwapTree from '../../../lib/swap/ReverseSwapTree';
-import { bitcoinClient, claimSwap, createSwapOutput, init } from '../Utils';
+import { OutputType } from '../../../lib/consts/Enums.ts';
+import reverseSwapTree from '../../../lib/swap/ReverseSwapTree.ts';
+import { bitcoinClient, claimSwap, createSwapOutput, init } from '../Utils.ts';
 
 describe('ReverseSwapTree claim', () => {
   beforeAll(async () => {

--- a/test/integration/reverseswapscript/ReverseSwapScriptClaim.spec.ts
+++ b/test/integration/reverseswapscript/ReverseSwapScriptClaim.spec.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'node:crypto';
-import { OutputType, reverseSwapScript } from '../../../lib/Boltz';
-import { bitcoinClient, claimSwap, createSwapOutput } from '../Utils';
+import { OutputType, reverseSwapScript } from '../../../lib/Boltz.ts';
+import { bitcoinClient, claimSwap, createSwapOutput } from '../Utils.ts';
 
 describe('ReverseSwapScript claim', () => {
   beforeAll(async () => {

--- a/test/integration/reverseswapscript/ReverseSwapScriptRefund.spec.ts
+++ b/test/integration/reverseswapscript/ReverseSwapScriptRefund.spec.ts
@@ -1,6 +1,6 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js';
-import { OutputType, reverseSwapScript } from '../../../lib/Boltz';
-import { bitcoinClient, createSwapOutput, refundSwap } from '../Utils';
+import { OutputType, reverseSwapScript } from '../../../lib/Boltz.ts';
+import { bitcoinClient, createSwapOutput, refundSwap } from '../Utils.ts';
 
 describe('ReverseSwapScript refund', () => {
   let bestBlockHeight: number;

--- a/test/integration/swapTree/SwapTreeClaim.spec.ts
+++ b/test/integration/swapTree/SwapTreeClaim.spec.ts
@@ -2,17 +2,17 @@ import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { SigHash } from '@scure/btc-signer';
 import { equalBytes } from '@scure/btc-signer/utils.js';
 import { randomBytes } from 'node:crypto';
-import { Musig, OutputType } from '../../../lib/Boltz';
-import { constructClaimTransaction } from '../../../lib/swap/Claim';
-import reverseSwapTree from '../../../lib/swap/ReverseSwapTree';
-import swapTree from '../../../lib/swap/SwapTree';
+import { Musig, OutputType } from '../../../lib/Boltz.ts';
+import { constructClaimTransaction } from '../../../lib/swap/Claim.ts';
+import reverseSwapTree from '../../../lib/swap/ReverseSwapTree.ts';
+import swapTree from '../../../lib/swap/SwapTree.ts';
 import {
   bitcoinClient,
   claimSwap,
   createSwapOutput,
   destinationOutput,
   init,
-} from '../Utils';
+} from '../Utils.ts';
 
 describe.each`
   name                 | treeFunc

--- a/test/integration/swapTree/SwapTreeRefund.spec.ts
+++ b/test/integration/swapTree/SwapTreeRefund.spec.ts
@@ -1,8 +1,8 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js';
-import { OutputType } from '../../../lib/consts/Enums';
-import reverseSwapTree from '../../../lib/swap/ReverseSwapTree';
-import swapTree from '../../../lib/swap/SwapTree';
-import { bitcoinClient, createSwapOutput, init, refundSwap } from '../Utils';
+import { OutputType } from '../../../lib/consts/Enums.ts';
+import reverseSwapTree from '../../../lib/swap/ReverseSwapTree.ts';
+import swapTree from '../../../lib/swap/SwapTree.ts';
+import { bitcoinClient, createSwapOutput, init, refundSwap } from '../Utils.ts';
 
 describe.each`
   name                 | treeFunc

--- a/test/integration/swapscript/SwapScriptClaim.spec.ts
+++ b/test/integration/swapscript/SwapScriptClaim.spec.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from 'node:crypto';
-import { OutputType, swapScript } from '../../../lib/Boltz';
-import swapTree from '../../../lib/swap/SwapTree';
-import { bitcoinClient, claimSwap, createSwapOutput, init } from '../Utils';
+import { OutputType, swapScript } from '../../../lib/Boltz.ts';
+import swapTree from '../../../lib/swap/SwapTree.ts';
+import { bitcoinClient, claimSwap, createSwapOutput, init } from '../Utils.ts';
 
 describe('SwapScript claim', () => {
   beforeAll(async () => {

--- a/test/integration/swapscript/SwapScriptRefund.spec.ts
+++ b/test/integration/swapscript/SwapScriptRefund.spec.ts
@@ -1,7 +1,7 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js';
-import { OutputType, swapScript } from '../../../lib/Boltz';
-import swapTree from '../../../lib/swap/SwapTree';
-import { bitcoinClient, createSwapOutput, init, refundSwap } from '../Utils';
+import { OutputType, swapScript } from '../../../lib/Boltz.ts';
+import swapTree from '../../../lib/swap/SwapTree.ts';
+import { bitcoinClient, createSwapOutput, init, refundSwap } from '../Utils.ts';
 
 describe('SwapScript refund', () => {
   let bestBlockHeight: number;

--- a/test/integration/utils/ChainClient.ts
+++ b/test/integration/utils/ChainClient.ts
@@ -1,4 +1,4 @@
-import RpcClient from './RpcClient';
+import RpcClient from './RpcClient.ts';
 
 enum AddressType {
   Legacy = 'legacy',

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.test.json",
+  "compilerOptions": {
+    "rootDir": ".."
+  },
+  "include": ["./**/*", "../lib/**/*"]
+}

--- a/test/unit/TargetFee.spec.ts
+++ b/test/unit/TargetFee.spec.ts
@@ -1,5 +1,5 @@
-import { constructClaimTransaction, targetFee } from '../../lib/Boltz';
-import { claimDetails } from './swap/ClaimDetails';
+import { constructClaimTransaction, targetFee } from '../../lib/Boltz.ts';
+import { claimDetails } from './swap/ClaimDetails.ts';
 
 describe('TargetFee', () => {
   test.each([1, 3, 12, 42, 32, 123])(

--- a/test/unit/liquid/TargetFee.spec.ts
+++ b/test/unit/liquid/TargetFee.spec.ts
@@ -1,8 +1,8 @@
-import zkp from '@vulpemventures/secp256k1-zkp';
 import { Transaction, confidential } from 'liquidjs-lib';
-import { targetFee } from '../../../lib/TargetFee';
-import { constructClaimTransaction, init } from '../../../lib/liquid';
-import { liquidClaimDetails } from './swap/ClaimDetails';
+import { targetFee } from '../../../lib/TargetFee.ts';
+import { constructClaimTransaction, init } from '../../../lib/liquid/index.ts';
+import zkp from '../../zkp.ts';
+import { liquidClaimDetails } from './swap/ClaimDetails.ts';
 
 describe.each([false, true])(
   'Liquid TargetFee (Discount CT = %p)',

--- a/test/unit/liquid/Utils.spec.ts
+++ b/test/unit/liquid/Utils.spec.ts
@@ -2,14 +2,14 @@ import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { hash160 } from '@scure/btc-signer/utils.js';
 import { randomBytes } from 'node:crypto';
-import { getScriptIntrospectionValues } from '../../../lib/liquid/Utils';
+import { getScriptIntrospectionValues } from '../../../lib/liquid/Utils.ts';
 import {
   p2pkhOutput,
   p2shOutput,
   p2trOutput,
   p2wpkhOutput,
   p2wshOutput,
-} from '../../../lib/swap/Scripts';
+} from '../../../lib/swap/Scripts.ts';
 
 describe('Liquid Utils', () => {
   test('should get P2TR introspection values', () => {

--- a/test/unit/liquid/init.spec.ts
+++ b/test/unit/liquid/init.spec.ts
@@ -1,7 +1,7 @@
 import type { Secp256k1ZKP } from '@vulpemventures/secp256k1-zkp';
-import zkp from '@vulpemventures/secp256k1-zkp';
 import { confidential } from 'liquidjs-lib';
-import { confidentialLiquid, init, secp } from '../../../lib/liquid/init';
+import { confidentialLiquid, init, secp } from '../../../lib/liquid/init.ts';
+import zkp from '../../zkp.ts';
 
 describe('Liquid init', () => {
   let ourSecp: Secp256k1ZKP;

--- a/test/unit/liquid/swap/Claim.spec.ts
+++ b/test/unit/liquid/swap/Claim.spec.ts
@@ -1,16 +1,19 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js';
-import zkp from '@vulpemventures/secp256k1-zkp';
 import { confidential } from 'liquidjs-lib';
-import { reverseBuffer } from 'liquidjs-lib/src/bufferutils';
+import { reverseBuffer } from 'liquidjs-lib/src/bufferutils.js';
 import { randomBytes } from 'node:crypto';
-import { OutputType } from '../../../../lib/consts/Enums';
-import { Errors } from '../../../../lib/consts/Errors';
-import type { LiquidClaimDetails } from '../../../../lib/liquid';
-import { constructClaimTransaction, init } from '../../../../lib/liquid';
-import { p2trOutput } from '../../../../lib/swap/Scripts';
-import { fundingAddressTree } from '../../../../lib/swap/SwapTree';
-import { toXOnly } from '../../../../lib/swap/TaprootUtils';
-import { lbtcRegtest, liquidClaimDetailsMap, nonce } from './ClaimDetails';
+import { OutputType } from '../../../../lib/consts/Enums.ts';
+import { Errors } from '../../../../lib/consts/Errors.ts';
+import type { LiquidClaimDetails } from '../../../../lib/liquid/index.ts';
+import {
+  constructClaimTransaction,
+  init,
+} from '../../../../lib/liquid/index.ts';
+import { p2trOutput } from '../../../../lib/swap/Scripts.ts';
+import { fundingAddressTree } from '../../../../lib/swap/SwapTree.ts';
+import { toXOnly } from '../../../../lib/swap/TaprootUtils.ts';
+import zkp from '../../../zkp.ts';
+import { lbtcRegtest, liquidClaimDetailsMap, nonce } from './ClaimDetails.ts';
 
 describe('Liquid Claim', () => {
   const testClaim = (utxos: LiquidClaimDetails[], fee: bigint) => {

--- a/test/unit/liquid/swap/ClaimDetails.ts
+++ b/test/unit/liquid/swap/ClaimDetails.ts
@@ -1,8 +1,8 @@
 import { Transaction, confidential } from 'liquidjs-lib';
-import type { OutputType } from '../../../../lib/consts/Enums';
-import type { LiquidClaimDetails } from '../../../../lib/liquid';
-import { Networks } from '../../../../lib/liquid';
-import { claimDetails } from '../../swap/ClaimDetails';
+import type { OutputType } from '../../../../lib/consts/Enums.ts';
+import type { LiquidClaimDetails } from '../../../../lib/liquid/index.ts';
+import { Networks } from '../../../../lib/liquid/index.ts';
+import { claimDetails } from '../../swap/ClaimDetails.ts';
 
 export const nonce = Buffer.from('00', 'hex');
 

--- a/test/unit/liquid/swap/PreimageDetector.spec.ts
+++ b/test/unit/liquid/swap/PreimageDetector.spec.ts
@@ -1,18 +1,21 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { hex } from '@scure/base';
 import { hash160 } from '@scure/btc-signer/utils.js';
-import zkp from '@vulpemventures/secp256k1-zkp';
 import { confidential } from 'liquidjs-lib';
-import { OutputType } from '../../../../lib/consts/Enums';
-import { constructClaimTransaction, init } from '../../../../lib/liquid';
-import { detectPreimage } from '../../../../lib/swap/PreimageDetector';
-import reverseSwapScript from '../../../../lib/swap/ReverseSwapScript';
+import { OutputType } from '../../../../lib/consts/Enums.ts';
+import {
+  constructClaimTransaction,
+  init,
+} from '../../../../lib/liquid/index.ts';
+import { detectPreimage } from '../../../../lib/swap/PreimageDetector.ts';
+import reverseSwapScript from '../../../../lib/swap/ReverseSwapScript.ts';
 import {
   outputFunctionForType,
   p2wpkhOutput,
-} from '../../../../lib/swap/Scripts';
-import swapScript from '../../../../lib/swap/SwapScript';
-import { lbtcRegtest, nonce } from './ClaimDetails';
+} from '../../../../lib/swap/Scripts.ts';
+import swapScript from '../../../../lib/swap/SwapScript.ts';
+import zkp from '../../../zkp.ts';
+import { lbtcRegtest, nonce } from './ClaimDetails.ts';
 
 describe('Liquid PreimageDetector', () => {
   const claimKeys = secp256k1.utils.randomSecretKey();

--- a/test/unit/liquid/swap/Refund.spec.ts
+++ b/test/unit/liquid/swap/Refund.spec.ts
@@ -1,10 +1,13 @@
-import zkp from '@vulpemventures/secp256k1-zkp';
 import { confidential } from 'liquidjs-lib';
-import { reverseBuffer } from 'liquidjs-lib/src/bufferutils';
-import { OutputType } from '../../../../lib/consts/Enums';
-import type { LiquidRefundDetails } from '../../../../lib/liquid';
-import { constructRefundTransaction, init } from '../../../../lib/liquid';
-import { lbtcRegtest, nonce } from './ClaimDetails';
+import { reverseBuffer } from 'liquidjs-lib/src/bufferutils.js';
+import { OutputType } from '../../../../lib/consts/Enums.ts';
+import type { LiquidRefundDetails } from '../../../../lib/liquid/index.ts';
+import {
+  constructRefundTransaction,
+  init,
+} from '../../../../lib/liquid/index.ts';
+import zkp from '../../../zkp.ts';
+import { lbtcRegtest, nonce } from './ClaimDetails.ts';
 
 describe('Liquid Refund', () => {
   const utxo: LiquidRefundDetails = {

--- a/test/unit/liquid/swap/ReverseSwapTree.spec.ts
+++ b/test/unit/liquid/swap/ReverseSwapTree.spec.ts
@@ -5,8 +5,8 @@ import {
   Feature,
   type FeatureOption,
   reverseSwapTree,
-} from '../../../../lib/liquid';
-import { p2trOutput } from '../../../../lib/swap/Scripts';
+} from '../../../../lib/liquid/index.ts';
+import { p2trOutput } from '../../../../lib/swap/Scripts.ts';
 
 describe('ReverseSwapTree', () => {
   test('should throw with duplicate features', () => {

--- a/test/unit/liquid/swap/SwapDetector.spec.ts
+++ b/test/unit/liquid/swap/SwapDetector.spec.ts
@@ -3,15 +3,15 @@ import { sha256 } from '@noble/hashes/sha2.js';
 import { hash160 } from '@scure/btc-signer/utils.js';
 import { script as bitcoinScript } from 'bitcoinjs-lib';
 import { Transaction, confidential } from 'liquidjs-lib';
-import { OutputType } from '../../../../lib/consts/Enums';
-import reverseSwapScript from '../../../../lib/swap/ReverseSwapScript';
+import { OutputType } from '../../../../lib/consts/Enums.ts';
+import reverseSwapScript from '../../../../lib/swap/ReverseSwapScript.ts';
 import {
   outputFunctionForType,
   p2pkhOutput,
-} from '../../../../lib/swap/Scripts';
-import { detectSwap } from '../../../../lib/swap/SwapDetector';
-import swapScript from '../../../../lib/swap/SwapScript';
-import { lbtcRegtest, nonce } from './ClaimDetails';
+} from '../../../../lib/swap/Scripts.ts';
+import { detectSwap } from '../../../../lib/swap/SwapDetector.ts';
+import swapScript from '../../../../lib/swap/SwapScript.ts';
+import { lbtcRegtest, nonce } from './ClaimDetails.ts';
 
 describe('Liquid SwapDetector', () => {
   test.each`

--- a/test/unit/liquid/swap/TaprootUtils.spec.ts
+++ b/test/unit/liquid/swap/TaprootUtils.spec.ts
@@ -1,22 +1,22 @@
-import ops from '@boltz/bitcoin-ops';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { hex } from '@scure/base';
-import zkp from '@vulpemventures/secp256k1-zkp';
-import { findScriptPath as liquidFindScriptPath } from 'liquidjs-lib/src/bip341';
+import { findScriptPath as liquidFindScriptPath } from 'liquidjs-lib/src/bip341.js';
 import { randomBytes } from 'node:crypto';
-import type { TapLeaf, TapTree } from '../../../../lib/consts/Types';
-import { init } from '../../../../lib/liquid';
-import { secp } from '../../../../lib/liquid/init';
+import type { TapLeaf, TapTree } from '../../../../lib/consts/Types.ts';
+import ops from '../../../../lib/internal/bitcoinOps.ts';
+import { init } from '../../../../lib/liquid/index.ts';
+import { secp } from '../../../../lib/liquid/init.ts';
 import {
   createControlBlock,
   tapLeafHash,
   tapTweakHash,
   toHashTree,
   tweakMusig,
-} from '../../../../lib/liquid/swap/TaprootUtils';
-import * as Musig from '../../../../lib/musig/Musig';
-import { fundingAddressTree } from '../../../../lib/swap/SwapTree';
-import { createLeaf, toXOnly } from '../../../../lib/swap/TaprootUtils';
+} from '../../../../lib/liquid/swap/TaprootUtils.ts';
+import * as Musig from '../../../../lib/musig/Musig.ts';
+import { fundingAddressTree } from '../../../../lib/swap/SwapTree.ts';
+import { createLeaf, toXOnly } from '../../../../lib/swap/TaprootUtils.ts';
+import zkp from '../../../zkp.ts';
 
 describe('TaprootUtils', () => {
   const publicKey = secp256k1.getPublicKey(

--- a/test/unit/liquid/swap/TaprootUtils.spec.ts
+++ b/test/unit/liquid/swap/TaprootUtils.spec.ts
@@ -1,9 +1,9 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { hex } from '@scure/base';
+import { opcodes } from 'liquidjs-lib';
 import { findScriptPath as liquidFindScriptPath } from 'liquidjs-lib/src/bip341.js';
 import { randomBytes } from 'node:crypto';
 import type { TapLeaf, TapTree } from '../../../../lib/consts/Types.ts';
-import ops from '../../../../lib/internal/bitcoinOps.ts';
 import { init } from '../../../../lib/liquid/index.ts';
 import { secp } from '../../../../lib/liquid/init.ts';
 import {
@@ -149,9 +149,9 @@ describe('TaprootUtils', () => {
       createControlBlock(
         toHashTree(taptree),
         createLeaf(true, [
-          ops.OP_RIPEMD160,
+          opcodes.OP_RIPEMD160,
           randomBytes(20),
-          ops.OP_EQUALVERIFY,
+          opcodes.OP_EQUALVERIFY,
         ]),
         Buffer.from(
           toXOnly(secp256k1.getPublicKey(secp256k1.utils.randomSecretKey())),

--- a/test/unit/musig/Musig.spec.ts
+++ b/test/unit/musig/Musig.spec.ts
@@ -1,9 +1,8 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { hex } from '@scure/base';
 import { nonceGen } from '@scure/btc-signer/musig2.js';
-import zkpInit, { type Secp256k1ZKP } from '@vulpemventures/secp256k1-zkp';
 import { randomBytes } from 'node:crypto';
-import * as Musig from '../../../lib/musig/Musig';
+import * as Musig from '../../../lib/musig/Musig.ts';
 import {
   MusigKeyAgg,
   MusigNoncesAggregated,
@@ -11,8 +10,9 @@ import {
   MusigSigned,
   MusigWithMessage,
   MusigWithNonce,
-} from '../../../lib/musig/Musig';
-import { toXOnly } from '../../../lib/swap/TaprootUtils';
+} from '../../../lib/musig/Musig.ts';
+import { toXOnly } from '../../../lib/swap/TaprootUtils.ts';
+import zkpInit, { type Secp256k1ZKP } from '../../zkp.ts';
 
 describe('Musig', () => {
   let secpZkp: Secp256k1ZKP;

--- a/test/unit/swap/Claim.spec.ts
+++ b/test/unit/swap/Claim.spec.ts
@@ -1,14 +1,14 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js';
-import { reverseBuffer } from 'liquidjs-lib/src/bufferutils';
+import { reverseBuffer } from 'liquidjs-lib/src/bufferutils.js';
 import { randomBytes } from 'node:crypto';
-import { OutputType } from '../../../lib/consts/Enums';
-import { Errors } from '../../../lib/consts/Errors';
-import type { ClaimDetails } from '../../../lib/consts/Types';
-import { constructClaimTransaction } from '../../../lib/swap/Claim';
-import { p2trOutput } from '../../../lib/swap/Scripts';
-import { fundingAddressTree } from '../../../lib/swap/SwapTree';
-import { toXOnly } from '../../../lib/swap/TaprootUtils';
-import { claimDetails, claimDetailsMap } from './ClaimDetails';
+import { OutputType } from '../../../lib/consts/Enums.ts';
+import { Errors } from '../../../lib/consts/Errors.ts';
+import type { ClaimDetails } from '../../../lib/consts/Types.ts';
+import { constructClaimTransaction } from '../../../lib/swap/Claim.ts';
+import { p2trOutput } from '../../../lib/swap/Scripts.ts';
+import { fundingAddressTree } from '../../../lib/swap/SwapTree.ts';
+import { toXOnly } from '../../../lib/swap/TaprootUtils.ts';
+import { claimDetails, claimDetailsMap } from './ClaimDetails.ts';
 
 describe('Claim', () => {
   const testClaim = (utxos: ClaimDetails[], fee: number) => {

--- a/test/unit/swap/ClaimDetails.ts
+++ b/test/unit/swap/ClaimDetails.ts
@@ -1,5 +1,5 @@
-import { OutputType } from '../../../lib/consts/Enums';
-import type { ClaimDetails } from '../../../lib/consts/Types';
+import { OutputType } from '../../../lib/consts/Enums.ts';
+import type { ClaimDetails } from '../../../lib/consts/Types.ts';
 
 const utxo = {
   transactionId:

--- a/test/unit/swap/PreimageDetector.spec.ts
+++ b/test/unit/swap/PreimageDetector.spec.ts
@@ -3,19 +3,19 @@ import { sha256 } from '@noble/hashes/sha2.js';
 import { hex } from '@scure/base';
 import { hash160 } from '@scure/btc-signer/utils.js';
 import { randomBytes } from 'node:crypto';
-import { OutputType } from '../../../lib/consts/Enums';
-import { constructClaimTransaction } from '../../../lib/swap/Claim';
-import { detectPreimage } from '../../../lib/swap/PreimageDetector';
-import reverseSwapScript from '../../../lib/swap/ReverseSwapScript';
-import reverseSwapTree from '../../../lib/swap/ReverseSwapTree';
+import { OutputType } from '../../../lib/consts/Enums.ts';
+import { constructClaimTransaction } from '../../../lib/swap/Claim.ts';
+import { detectPreimage } from '../../../lib/swap/PreimageDetector.ts';
+import reverseSwapScript from '../../../lib/swap/ReverseSwapScript.ts';
+import reverseSwapTree from '../../../lib/swap/ReverseSwapTree.ts';
 import {
   outputFunctionForType,
   p2trOutput,
   p2wpkhOutput,
-} from '../../../lib/swap/Scripts';
-import swapScript from '../../../lib/swap/SwapScript';
-import swapTree from '../../../lib/swap/SwapTree';
-import { toXOnly } from '../../../lib/swap/TaprootUtils';
+} from '../../../lib/swap/Scripts.ts';
+import swapScript from '../../../lib/swap/SwapScript.ts';
+import swapTree from '../../../lib/swap/SwapTree.ts';
+import { toXOnly } from '../../../lib/swap/TaprootUtils.ts';
 
 describe('PreimageDetector', () => {
   const claimKeys = secp256k1.utils.randomSecretKey();

--- a/test/unit/swap/Refund.spec.ts
+++ b/test/unit/swap/Refund.spec.ts
@@ -1,7 +1,7 @@
 import { hex } from '@scure/base';
-import { OutputType } from '../../../lib/consts/Enums';
-import type { RefundDetails } from '../../../lib/consts/Types';
-import { constructRefundTransaction } from '../../../lib/swap/Refund';
+import { OutputType } from '../../../lib/consts/Enums.ts';
+import type { RefundDetails } from '../../../lib/consts/Types.ts';
+import { constructRefundTransaction } from '../../../lib/swap/Refund.ts';
 
 describe('Refund', () => {
   const utxo = {

--- a/test/unit/swap/ReverseSwapScript.spec.ts
+++ b/test/unit/swap/ReverseSwapScript.spec.ts
@@ -1,5 +1,5 @@
 import { hex } from '@scure/base';
-import reverseSwapScript from '../../../lib/swap/ReverseSwapScript';
+import reverseSwapScript from '../../../lib/swap/ReverseSwapScript.ts';
 
 describe('ReverseSwapScript', () => {
   test('should get a reverse swap script', () => {

--- a/test/unit/swap/ReverseSwapTree.spec.ts
+++ b/test/unit/swap/ReverseSwapTree.spec.ts
@@ -4,8 +4,8 @@ import {
   extractClaimPublicKeyFromReverseSwapTree,
   extractRefundPublicKeyFromReverseSwapTree,
   reverseSwapTree,
-} from '../../../lib/Boltz';
-import { toXOnly } from '../../../lib/swap/TaprootUtils';
+} from '../../../lib/Boltz.ts';
+import { toXOnly } from '../../../lib/swap/TaprootUtils.ts';
 
 describe('ReverseSwapTree', () => {
   test('should extract claim public key from swap tree', () => {

--- a/test/unit/swap/Scripts.spec.ts
+++ b/test/unit/swap/Scripts.spec.ts
@@ -1,5 +1,5 @@
 import { hex } from '@scure/base';
-import { OutputType } from '../../../lib/consts/Enums';
+import { OutputType } from '../../../lib/consts/Enums.ts';
 import {
   outputFunctionForType,
   p2pkhOutput,
@@ -9,8 +9,8 @@ import {
   p2trOutput,
   p2wpkhOutput,
   p2wshOutput,
-} from '../../../lib/swap/Scripts';
-import { toXOnly } from '../../../lib/swap/TaprootUtils';
+} from '../../../lib/swap/Scripts.ts';
+import { toXOnly } from '../../../lib/swap/TaprootUtils.ts';
 
 describe('Scripts', () => {
   const key = toXOnly(

--- a/test/unit/swap/SwapDetector.spec.ts
+++ b/test/unit/swap/SwapDetector.spec.ts
@@ -3,16 +3,16 @@ import { sha256 } from '@noble/hashes/sha2.js';
 import { Script, Transaction } from '@scure/btc-signer';
 import { hash160 } from '@scure/btc-signer/utils.js';
 import { randomBytes } from 'node:crypto';
-import { OutputType } from '../../../lib/consts/Enums';
-import reverseSwapScript from '../../../lib/swap/ReverseSwapScript';
+import { OutputType } from '../../../lib/consts/Enums.ts';
+import reverseSwapScript from '../../../lib/swap/ReverseSwapScript.ts';
 import {
   outputFunctionForType,
   p2pkhOutput,
   p2trOutput,
-} from '../../../lib/swap/Scripts';
-import { detectSwap } from '../../../lib/swap/SwapDetector';
-import swapScript from '../../../lib/swap/SwapScript';
-import { toXOnly } from '../../../lib/swap/TaprootUtils';
+} from '../../../lib/swap/Scripts.ts';
+import { detectSwap } from '../../../lib/swap/SwapDetector.ts';
+import swapScript from '../../../lib/swap/SwapScript.ts';
+import { toXOnly } from '../../../lib/swap/TaprootUtils.ts';
 
 describe('SwapDetector', () => {
   test.each`

--- a/test/unit/swap/SwapScript.spec.ts
+++ b/test/unit/swap/SwapScript.spec.ts
@@ -1,5 +1,5 @@
 import { hex } from '@scure/base';
-import swapScript from '../../../lib/swap/SwapScript';
+import swapScript from '../../../lib/swap/SwapScript.ts';
 
 describe('SwapScript', () => {
   test('should get a swap script', () => {

--- a/test/unit/swap/SwapTree.spec.ts
+++ b/test/unit/swap/SwapTree.spec.ts
@@ -7,8 +7,8 @@ import {
   extractRefundPublicKeyFromSwapTree,
   fundingAddressTree,
   swapTree,
-} from '../../../lib/Boltz';
-import { toXOnly, tweakMusig } from '../../../lib/swap/TaprootUtils';
+} from '../../../lib/Boltz.ts';
+import { toXOnly, tweakMusig } from '../../../lib/swap/TaprootUtils.ts';
 
 describe('SwapTree', () => {
   test('should extract claim public key from swap tree', () => {

--- a/test/unit/swap/SwapTreeCompare.spec.ts
+++ b/test/unit/swap/SwapTreeCompare.spec.ts
@@ -1,7 +1,7 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { randomBytes } from 'node:crypto';
-import swapTree from '../../../lib/swap/SwapTree';
-import { compareTrees } from '../../../lib/swap/SwapTreeCompare';
+import swapTree from '../../../lib/swap/SwapTree.ts';
+import { compareTrees } from '../../../lib/swap/SwapTreeCompare.ts';
 
 describe('SwapTreeCompare', () => {
   const claimKey = secp256k1.getPublicKey(secp256k1.utils.randomSecretKey());

--- a/test/unit/swap/SwapTreeSerializer.spec.ts
+++ b/test/unit/swap/SwapTreeSerializer.spec.ts
@@ -1,14 +1,18 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { hex } from '@scure/base';
-import { Feature, Networks, reverseSwapTree } from '../../../lib/liquid';
-import { p2trOutput } from '../../../lib/swap/Scripts';
-import swapTree, { fundingAddressTree } from '../../../lib/swap/SwapTree';
+import {
+  Feature,
+  Networks,
+  reverseSwapTree,
+} from '../../../lib/liquid/index.ts';
+import { p2trOutput } from '../../../lib/swap/Scripts.ts';
+import swapTree, { fundingAddressTree } from '../../../lib/swap/SwapTree.ts';
 import {
   deserializeFundingAddressTree,
   deserializeSwapTree,
   serializeFundingAddressTree,
   serializeSwapTree,
-} from '../../../lib/swap/SwapTreeSerializer';
+} from '../../../lib/swap/SwapTreeSerializer.ts';
 
 describe('SwapTreeSerializer', () => {
   const preimageHash = Buffer.from(

--- a/test/unit/swap/TaprootUtils.spec.ts
+++ b/test/unit/swap/TaprootUtils.spec.ts
@@ -2,11 +2,10 @@ import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { hex } from '@scure/base';
 import { Script, type ScriptType } from '@scure/btc-signer';
 import { TAP_LEAF_VERSION } from '@scure/btc-signer/payment.js';
-import zkp from '@vulpemventures/secp256k1-zkp';
-import { tapTweakHash } from 'bitcoinjs-lib/src/payments/bip341';
+import { tapTweakHash } from 'bitcoinjs-lib/src/payments/bip341.js';
 import { randomBytes } from 'node:crypto';
-import type { TapLeaf, TapTree } from '../../../lib/consts/Types';
-import * as Musig from '../../../lib/musig/Musig';
+import type { TapLeaf, TapTree } from '../../../lib/consts/Types.ts';
+import * as Musig from '../../../lib/musig/Musig.ts';
 import {
   TAP_LEAF_VERSION_LIQUID,
   createControlBlock,
@@ -15,7 +14,8 @@ import {
   taprootHashTree,
   toXOnly,
   tweakMusig,
-} from '../../../lib/swap/TaprootUtils';
+} from '../../../lib/swap/TaprootUtils.ts';
+import zkp from '../../zkp.ts';
 
 describe('TaprootUtils', () => {
   const taptree: TapTree = [

--- a/test/unit/swap/TreeSort.spec.ts
+++ b/test/unit/swap/TreeSort.spec.ts
@@ -1,6 +1,9 @@
-import type { LiquidSwapTree, TapTree } from '../../../lib/consts/Types';
-import { createLeaf } from '../../../lib/swap/TaprootUtils';
-import { assignTreeProbabilities, sortTree } from '../../../lib/swap/TreeSort';
+import type { LiquidSwapTree, TapTree } from '../../../lib/consts/Types.ts';
+import { createLeaf } from '../../../lib/swap/TaprootUtils.ts';
+import {
+  assignTreeProbabilities,
+  sortTree,
+} from '../../../lib/swap/TreeSort.ts';
 
 describe('TreeSort', () => {
   test.each`

--- a/test/zkp.ts
+++ b/test/zkp.ts
@@ -1,0 +1,9 @@
+import zkpImport, { type Secp256k1ZKP } from '@vulpemventures/secp256k1-zkp';
+
+type Init = typeof zkpImport.default;
+
+const initZkp: Init =
+  (zkpImport as { default?: Init }).default ?? (zkpImport as unknown as Init);
+
+export type { Secp256k1ZKP };
+export default initZkp;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
+    "isolatedDeclarations": true,
 
     /* Type Checking */
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     /* Modules */
     "module": "Node20",
     "resolveJsonModule": true,
+    "rewriteRelativeImportExtensions": true,
 
     /* Emit */
     "outDir": "./dist",
@@ -23,6 +24,7 @@
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "isolatedDeclarations": true,
+    "verbatimModuleSyntax": true,
 
     /* Type Checking */
     "strict": true,

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "types": ["node", "jest"],
-    "noEmit": true
+    "noEmit": true,
+    "isolatedDeclarations": false
   },
   "include": ["test/**/*", "lib/**/*"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Minimum Node.js version increased to 20.10 (from 20.0)
  * Removed CommonJS support; package is now ESM-only

* **Improvements**
  * Added Node.js 26 to test matrix
  * Enhanced TypeScript module resolution and type safety

* **Version**
  * Bumped to 5.0.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->